### PR TITLE
feat: support catr claim and automatic renewal support in HTTP handlers

### DIFF
--- a/examples/server.ts
+++ b/examples/server.ts
@@ -16,7 +16,7 @@ const httpValidator = new HttpValidator({
 });
 
 const server = http.createServer(async (req, res) => {
-  const result = await httpValidator.validateHttpRequest(req, 'Symmetric256');
+  const result = await httpValidator.validateHttpRequest(req, res);
   res.writeHead(result.status, { 'Content-Type': 'text/plain' });
   res.end(result.message || 'ok');
 });

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@
 This is a Node library for generating and validating Common Access Tokens (CTA-5007).
 
 Features:
+
 - Generate and Validate Common Access Tokens. Supported claims in table below.
 - HTTP and CloudFront Lambda handlers supporting
   - Validation and parsing of tokens

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ This is a Node library for generating and validating Common Access Tokens (CTA-5
 | Geohash (`geohash`)                                       | No       |
 | Common Access Token Altitude (`catgeoalt`)                | No       |
 | Common Access Token TLS Public Key (`cattpk`)             | No       |
+| Common ACcess Token Renewal (`catr`) claim                | Yes      |
 
 ## Requirements
 

--- a/readme.md
+++ b/readme.md
@@ -142,8 +142,9 @@ export const handler = async (
   const request = event.Records[0].cf.request;
   const response = event.Records[0].cf.response;
   const result = await httpValidator.validateCloudFrontRequest(request);
-  response.status = result.status;
-  response.statusDescription = result.message;
+  // If renewed new token is found here given catr type is "header"
+  console.log(result.cfResponse.headers['cta-common-access-token']);
+  response = result.cfResponse;
   if (result.claims) {
     console.log(result.claims);
   }

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ const httpValidator = new HttpValidator({
       )
     }
   ],
+  autoRenewEnabled: true // Token renewal enabled. Optional (default: true)
   tokenMandatory: true // Optional (default: true)
   issuer: 'eyevinn',
   audience: ['one', 'two'] // Optional
@@ -79,9 +80,10 @@ const httpValidator = new HttpValidator({
 
 const server = http.createServer((req, res) => {
   const result = await httpValidator.validateHttpRequest(
-    req
+    req, res
   );
-  console.log(result.claims);
+  console.log(result.claims); // Claims
+  console.log(res.getHeaders('cta-common-access-token')); // Renewed token
   res.writeHead(result.status, { 'Content-Type': 'text/plain' });
   res.end(result.message || 'ok');
 });

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,13 @@
 
 </div>
 
-This is a Node library for generating and validating Common Access Tokens (CTA-5007)
+This is a Node library for generating and validating Common Access Tokens (CTA-5007).
+
+Features:
+- Generate and Validate Common Access Tokens. Supported claims in table below.
+- HTTP and CloudFront Lambda handlers supporting
+  - Validation and parsing of tokens
+  - Handle automatic renewal of tokens
 
 ## Claims Validation Support
 

--- a/src/cat.test.ts
+++ b/src/cat.test.ts
@@ -1,4 +1,5 @@
 import { CommonAccessToken, CommonAccessTokenFactory } from './cat';
+import { CommonAccessTokenRenewal } from './catr';
 
 describe('CAT', () => {
   test('can create a CAT object and return claims as JSON', () => {
@@ -126,6 +127,20 @@ describe('CAT', () => {
       nbf: 1443944944,
       iat: 1443944944,
       cti: '0b71'
+    });
+  });
+
+  test('can provide information about renewal mechanism', async () => {
+    const cat = new CommonAccessToken({
+      iss: 'eyevinn',
+      catr: CommonAccessTokenRenewal.fromDict({
+        type: 'header',
+        'header-name': 'cta-common-access-token'
+      }).payload
+    });
+    expect(cat.claims.catr).toEqual({
+      type: 'header',
+      'header-name': 'cta-common-access-token'
     });
   });
 });

--- a/src/cat.test.ts
+++ b/src/cat.test.ts
@@ -143,4 +143,36 @@ describe('CAT', () => {
       'header-name': 'cta-common-access-token'
     });
   });
+
+  test('can determine whether the token should be renewed', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const cat = new CommonAccessToken({
+      iss: 'eyevinn',
+      exp: now + 30,
+      catr: CommonAccessTokenRenewal.fromDict({
+        type: 'automatic',
+        extadd: 60
+      }).payload
+    });
+    expect(cat.shouldRenew).toBe(true);
+    const cat2 = new CommonAccessToken({
+      iss: 'eyevinn',
+      exp: now + 100,
+      catr: CommonAccessTokenRenewal.fromDict({
+        type: 'automatic',
+        extadd: 60
+      }).payload
+    });
+    expect(cat2.shouldRenew).toBe(false);
+    const cat3 = new CommonAccessToken({
+      iss: 'eyevinn',
+      exp: now + 100,
+      catr: CommonAccessTokenRenewal.fromDict({
+        type: 'automatic',
+        extadd: 60,
+        deadline: 105
+      }).payload
+    });
+    expect(cat3.shouldRenew).toBe(true);
+  });
 });

--- a/src/cat.test.ts
+++ b/src/cat.test.ts
@@ -144,6 +144,35 @@ describe('CAT', () => {
     });
   });
 
+  test('can create a CAT object from a dict', async () => {
+    const cat = CommonAccessTokenFactory.fromDict({
+      iss: 'eyevinn',
+      sub: 'jonas',
+      aud: 'coap://light.example.com',
+      exp: 1444064944,
+      nbf: 1443944944,
+      iat: 1443944944,
+      cti: '0b71',
+      catr: {
+        type: 'header',
+        'header-name': 'cta-common-access-token'
+      }
+    });
+    expect(cat.claims).toEqual({
+      iss: 'eyevinn',
+      sub: 'jonas',
+      aud: 'coap://light.example.com',
+      exp: 1444064944,
+      nbf: 1443944944,
+      iat: 1443944944,
+      cti: '0b71',
+      catr: {
+        type: 'header',
+        'header-name': 'cta-common-access-token'
+      }
+    });
+  });
+
   test('can determine whether the token should be renewed', async () => {
     const now = Math.floor(Date.now() / 1000);
     const cat = new CommonAccessToken({
@@ -151,7 +180,7 @@ describe('CAT', () => {
       exp: now + 30,
       catr: CommonAccessTokenRenewal.fromDict({
         type: 'automatic',
-        extadd: 60
+        expadd: 60
       }).payload
     });
     expect(cat.shouldRenew).toBe(true);
@@ -160,7 +189,7 @@ describe('CAT', () => {
       exp: now + 100,
       catr: CommonAccessTokenRenewal.fromDict({
         type: 'automatic',
-        extadd: 60
+        expadd: 60
       }).payload
     });
     expect(cat2.shouldRenew).toBe(false);
@@ -169,7 +198,7 @@ describe('CAT', () => {
       exp: now + 100,
       catr: CommonAccessTokenRenewal.fromDict({
         type: 'automatic',
-        extadd: 60,
+        expadd: 60,
         deadline: 105
       }).payload
     });

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -133,6 +133,30 @@ function updateMapFromClaims(
   return map;
 }
 
+function updateMapFromDict(
+  dict: CommonAccessTokenDict
+): CommonAccessTokenClaims {
+  const claims: CommonAccessTokenClaims = {};
+  for (const param in dict) {
+    const key = claimsToLabels[param];
+    if (param === 'catu') {
+      claims[key] = CommonAccessTokenUri.fromDict(
+        dict[param] as { [key: string]: any }
+      ).payload;
+    } else if (param === 'catr') {
+      claims[key] = CommonAccessTokenRenewal.fromDict(
+        dict[param] as { [key: string]: any }
+      ).payload;
+    } else {
+      const value = claimTransform[param]
+        ? claimTransform[param](dict[param] as string)
+        : dict[param];
+      claims[key] = value as string | number;
+    }
+  }
+  return claims;
+}
+
 export class CommonAccessToken {
   private payload: Map<number, CommonAccessTokenValue>;
   private data?: Buffer;
@@ -351,6 +375,11 @@ export class CommonAccessTokenFactory {
     const token = Buffer.from(base64encoded, 'base64');
     const cat = new CommonAccessToken({});
     await cat.parse(token, key, { expectCwtTag });
+    return cat;
+  }
+
+  public static fromDict(claims: CommonAccessTokenDict) {
+    const cat = new CommonAccessToken(updateMapFromDict(claims));
     return cat;
   }
 }

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -10,6 +10,7 @@ import {
 } from './errors';
 import { CatValidationOptions } from '.';
 import { CommonAccessTokenUri } from './catu';
+import { CommonAccessTokenRenewal } from './catr';
 
 const claimsToLabels: { [key: string]: number } = {
   iss: 1, // 3
@@ -281,6 +282,10 @@ export class CommonAccessToken {
       const key = labelsToClaim[param] ? labelsToClaim[param] : param;
       if (key === 'catu') {
         result[key] = CommonAccessTokenUri.fromMap(
+          value as Map<number, any>
+        ).toDict();
+      } else if (key === 'catr') {
+        result[key] = CommonAccessTokenRenewal.fromMap(
           value as Map<number, any>
         ).toDict();
       } else {

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -320,6 +320,7 @@ export class CommonAccessToken {
         if (renewal.deadline !== undefined) {
           lowThreshold = exp - renewal.deadline;
         }
+        //console.log(`${now} >= ${lowThreshold} && ${now} < ${exp}`);
         if (now >= lowThreshold && now < exp) {
           return true;
         }

--- a/src/catr.ts
+++ b/src/catr.ts
@@ -54,7 +54,10 @@ export class CommonAccessTokenRenewal {
   public static fromDict(dict: { [key: string]: any }) {
     const catr = new CommonAccessTokenRenewal();
     for (const catrPart in dict) {
-      catr.catrMap.set(catrPartToLabel[catrPart], dict[catrPart]);
+      catr.catrMap.set(
+        catrPartToLabel[catrPart],
+        catrRenewalTypeToLabel[dict[catrPart]] || dict[catrPart]
+      );
     }
     return catr;
   }
@@ -68,7 +71,11 @@ export class CommonAccessTokenRenewal {
   toDict() {
     const result: { [key: string]: any } = {};
     for (const [key, value] of this.catrMap.entries()) {
-      result[labelsToCatrPart[key]] = value;
+      if (labelsToCatrPart[key] === 'type') {
+        result[labelsToCatrPart[key]] = labelsToCatrRenewalType[value as number];
+      } else {
+        result[labelsToCatrPart[key]] = value;
+      }
     }
     return result;
   }

--- a/src/catr.ts
+++ b/src/catr.ts
@@ -54,10 +54,14 @@ export class CommonAccessTokenRenewal {
   public static fromDict(dict: { [key: string]: any }) {
     const catr = new CommonAccessTokenRenewal();
     for (const catrPart in dict) {
-      catr.catrMap.set(
-        catrPartToLabel[catrPart],
-        catrRenewalTypeToLabel[dict[catrPart]] || dict[catrPart]
-      );
+      if (catrPart === 'type') {
+        catr.catrMap.set(
+          catrPartToLabel[catrPart],
+          catrRenewalTypeToLabel[dict[catrPart]]
+        );
+      } else {
+        catr.catrMap.set(catrPartToLabel[catrPart], dict[catrPart]);
+      }
     }
     return catr;
   }
@@ -72,7 +76,8 @@ export class CommonAccessTokenRenewal {
     const result: { [key: string]: any } = {};
     for (const [key, value] of this.catrMap.entries()) {
       if (labelsToCatrPart[key] === 'type') {
-        result[labelsToCatrPart[key]] = labelsToCatrRenewalType[value as number];
+        result[labelsToCatrPart[key]] =
+          labelsToCatrRenewalType[value as number];
       } else {
         result[labelsToCatrPart[key]] = value;
       }

--- a/src/catr.ts
+++ b/src/catr.ts
@@ -73,6 +73,16 @@ export class CommonAccessTokenRenewal {
     return result;
   }
 
+  isValid() {
+    if (this.catrMap.get(catrPartToLabel['type']) === undefined) {
+      return false;
+    }
+    if (this.catrMap.get(catrPartToLabel['expadd']) === undefined) {
+      return false;
+    }
+    return true;
+  }
+
   get renewalType(): CatrRenewalType {
     const type = this.catrMap.get(catrPartToLabel['type']);
     return labelsToCatrRenewalType[type as number];

--- a/src/catr.ts
+++ b/src/catr.ts
@@ -1,0 +1,84 @@
+type CatrPart =
+  | 'type'
+  | 'expadd'
+  | 'deadline'
+  | 'cookie-name'
+  | 'header-name'
+  | 'cookie-params'
+  | 'header-params'
+  | 'code';
+
+type CatrRenewalType = 'automatic' | 'cookie' | 'header' | 'redirect';
+
+const catrPartToLabel: { [key: string]: number } = {
+  type: 0,
+  expadd: 1,
+  deadline: 2,
+  'cookie-name': 3,
+  'header-name': 4,
+  'cookie-params': 5,
+  'header-params': 6,
+  code: 7
+};
+
+const labelsToCatrPart: { [key: number]: CatrPart } = {
+  0: 'type',
+  1: 'expadd',
+  2: 'deadline',
+  3: 'cookie-name',
+  4: 'header-name',
+  5: 'cookie-params',
+  6: 'header-params',
+  7: 'code'
+};
+
+const catrRenewalTypeToLabel: { [key: string]: number } = {
+  automatic: 0,
+  cookie: 1,
+  header: 2,
+  redirect: 3
+};
+const labelsToCatrRenewalType: { [key: number]: CatrRenewalType } = {
+  0: 'automatic',
+  1: 'cookie',
+  2: 'header',
+  3: 'redirect'
+};
+
+type CatrPartValue = number | string | string[];
+export type CommonAccessTokenRenewalMap = Map<number, CatrPartValue>;
+
+export class CommonAccessTokenRenewal {
+  private catrMap: CommonAccessTokenRenewalMap = new Map();
+
+  public static fromDict(dict: { [key: string]: any }) {
+    const catr = new CommonAccessTokenRenewal();
+    for (const catrPart in dict) {
+      catr.catrMap.set(catrPartToLabel[catrPart], dict[catrPart]);
+    }
+    return catr;
+  }
+
+  public static fromMap(map: CommonAccessTokenRenewalMap) {
+    const catr = new CommonAccessTokenRenewal();
+    catr.catrMap = map;
+    return catr;
+  }
+
+  toDict() {
+    const result: { [key: string]: any } = {};
+    for (const [key, value] of this.catrMap.entries()) {
+      result[labelsToCatrPart[key]] = value;
+    }
+    return result;
+  }
+
+  get renewalType(): CatrRenewalType {
+    const type = this.catrMap.get(catrPartToLabel['type']);
+    return labelsToCatrRenewalType[type as number];
+  }
+
+  get payload() {
+    return this.catrMap;
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,3 +47,9 @@ export class UriNotAllowedError extends Error {
     super(reason);
   }
 }
+
+export class RenewalClaimError extends Error {
+  constructor(reason: string) {
+    super(reason);
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -359,7 +359,8 @@ describe('CAT claims', () => {
         catr: CommonAccessTokenRenewal.fromDict({
           type: 'header',
           'header-name': 'cta-common-access-token',
-          expadd: 120
+          expadd: 120,
+          deadline: 60
         }).payload
       },
       {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { CAT } from '.';
+import { CommonAccessTokenRenewal } from './catr';
 import { CommonAccessTokenUri } from './catu';
 import {
   InvalidAudienceError,
@@ -347,5 +348,39 @@ describe('CAT claims', () => {
     expect(result.error).not.toBeDefined();
     expect(result.cat).toBeDefined();
     expect(result.cat!.claims.cti).toBeDefined();
+  });
+
+  test('can renew a token', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const base64encoded = await generator.generate(
+      {
+        iss: 'eyevinn',
+        exp: now,
+        catr: CommonAccessTokenRenewal.fromDict({
+          type: 'header',
+          'header-name': 'cta-common-access-token',
+          expadd: 120
+        }).payload
+      },
+      {
+        type: 'mac',
+        alg: 'HS256',
+        kid: 'Symmetric256',
+        generateCwtId: true
+      }
+    );
+    const result = await validator.validate(base64encoded!, 'mac', {
+      issuer: 'eyevinn'
+    });
+    const renewed = await validator.renewToken(result.cat!, {
+      type: 'mac',
+      issuer: 'renew',
+      kid: 'Symmetric256',
+      alg: 'HS256'
+    });
+    const result2 = await validator.validate(renewed, 'mac', {
+      issuer: 'renew'
+    });
+    expect((result2.cat?.claims.exp as number) - now == 120).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR adds support for the `catr` claim (Common Access Token Renewal) and functionality in HTTP handlers for automatic renewal of tokens when a token is within a specified expiration window.