### PR TITLE
feat: plugin framework for storing token usage counts

### DIFF
--- a/examples/server.ts
+++ b/examples/server.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 
-import { HttpValidator } from '../src';
+import { HttpValidator, MemoryCTIStore } from '../src';
 
 const httpValidator = new HttpValidator({
   keys: [
@@ -12,7 +12,8 @@ const httpValidator = new HttpValidator({
       )
     }
   ],
-  issuer: 'eyevinn'
+  issuer: 'eyevinn',
+  store: new MemoryCTIStore()
 });
 
 const server = http.createServer(async (req, res) => {

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 
-import { HttpValidator, MemoryCTIStore } from '../src';
+import { HttpValidator, RedisCTIStore } from '../src';
 
 const httpValidator = new HttpValidator({
   keys: [
@@ -13,11 +13,14 @@ const httpValidator = new HttpValidator({
     }
   ],
   issuer: 'eyevinn',
-  store: new MemoryCTIStore()
+  store: new RedisCTIStore(
+    new URL(process.env.REDIS_URL || 'redis://localhost:6379')
+  )
 });
 
 const server = http.createServer(async (req, res) => {
   const result = await httpValidator.validateHttpRequest(req, res);
+  console.log(result);
   res.writeHead(result.status, { 'Content-Type': 'text/plain' });
   res.end(result.message || 'ok');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "cbor-x": "^1.6.0",
-        "cose-js": "^0.9.0"
+        "cose-js": "^0.9.0",
+        "ioredis": "^5.6.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -1922,6 +1923,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4535,6 +4542,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4774,7 +4790,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4883,6 +4898,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6203,6 +6227,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.0.tgz",
+      "integrity": "sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -7314,6 +7362,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -7689,7 +7749,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -8488,6 +8547,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8866,6 +8946,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "cbor-x": "^1.6.0",
-    "cose-js": "^0.9.0"
+    "cose-js": "^0.9.0",
+    "ioredis": "^5.6.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Features:
 ### Validate CTA Common Access Token in HTTP incoming message
 
 ```javascript
-import { HttpValidator } from '@eyevinn/cat';
+import { HttpValidator, MemoryCTIStore } from '@eyevinn/cat';
 
 const httpValidator = new HttpValidator({
   keys: [
@@ -83,7 +83,8 @@ const httpValidator = new HttpValidator({
   autoRenewEnabled: true // Token renewal enabled. Optional (default: true)
   tokenMandatory: true // Optional (default: true)
   issuer: 'eyevinn',
-  audience: ['one', 'two'] // Optional
+  audience: ['one', 'two'], // Optional
+  store: new MemoryCTIStore() // Where to store token usage count. Optional (default: none)
 });
 
 const server = http.createServer((req, res) => {
@@ -92,6 +93,7 @@ const server = http.createServer((req, res) => {
   );
   console.log(result.claims); // Claims
   console.log(res.getHeaders('cta-common-access-token')); // Renewed token
+  console.log(result.count); // Number of times the token has been used
   res.writeHead(result.status, { 'Content-Type': 'text/plain' });
   res.end(result.message || 'ok');
 });
@@ -152,6 +154,7 @@ export const handler = async (
   const result = await httpValidator.validateCloudFrontRequest(request);
   // If renewed new token is found here given catr type is "header"
   console.log(result.cfResponse.headers['cta-common-access-token']);
+  console.log(result.count); // Number of times the token has been used (undefined if no store is enabled)
   response = result.cfResponse;
   if (result.claims) {
     console.log(result.claims);

--- a/readme.md
+++ b/readme.md
@@ -250,7 +250,7 @@ const store = new RedisCTIStore('redis://localhost:6379');
 
 ### Custom Store
 
-To implement your own store you implement the interface `ICatStore`, for example:
+To implement your own store you implement the interface `ICTIStore`, for example:
 
 ```javascript
 import { ICTIStore, CommonAccessToken } from '@eyvinn/cat';

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Features:
 | Geohash (`geohash`)                                       | No       |
 | Common Access Token Altitude (`catgeoalt`)                | No       |
 | Common Access Token TLS Public Key (`cattpk`)             | No       |
-| Common ACcess Token Renewal (`catr`) claim                | Yes      |
+| Common Access Token Renewal (`catr`) claim                | Yes      |
 
 ## Requirements
 

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -329,6 +329,14 @@ export class CommonAccessToken {
     return false;
   }
 
+  get cti(): string | undefined {
+    const tokenId = this.payload.get(claimsToLabels['cti']);
+    if (tokenId) {
+      return claimTransformReverse['cti'](tokenId as Buffer);
+    }
+    return undefined;
+  }
+
   get claims(): CommonAccessTokenDict {
     const result: CommonAccessTokenDict = {};
     this.payload.forEach((value, param) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -347,7 +347,7 @@ describe('CAT claims', () => {
     });
     expect(result.error).not.toBeDefined();
     expect(result.cat).toBeDefined();
-    expect(result.cat!.claims.cti).toBeDefined();
+    expect(result.cat!.cti).toBeDefined();
   });
 
   test('can renew a token', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { KeyNotFoundError } from './errors';
 
 export { CommonAccessToken } from './cat';
 export { HttpValidator } from './validators/http';
+export { MemoryCTIStore } from './stores/memory';
 export { CommonAccessTokenRenewal } from './catr';
 export { CommonAccessTokenUri } from './catu';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,13 @@ import { CommonAccessToken, CommonAccessTokenFactory } from './cat';
 import { KeyNotFoundError } from './errors';
 
 export { CommonAccessToken } from './cat';
-export { HttpValidator } from './validators/http';
-export { MemoryCTIStore } from './stores/memory';
 export { CommonAccessTokenRenewal } from './catr';
 export { CommonAccessTokenUri } from './catu';
+
+export { HttpValidator } from './validators/http';
+export { ICTIStore } from './stores/interface';
+export { MemoryCTIStore } from './stores/memory';
+export { RedisCTIStore } from './stores/redis';
 
 export type CatValidationTypes = 'mac' | 'sign' | 'none';
 

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -1,6 +1,6 @@
-import { CommonAccessToken } from "..";
+import { CommonAccessToken } from '..';
 
 export interface CTIStore {
-  storeToken(token: CommonAccessToken): Promise<void>;
+  storeToken(token: CommonAccessToken): Promise<number>;
   getTokenCount(token: CommonAccessToken): Promise<number>;
 }

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -1,6 +1,6 @@
 import { CommonAccessToken } from '..';
 
-export interface CTIStore {
+export interface ICTIStore {
   storeToken(token: CommonAccessToken): Promise<number>;
   getTokenCount(token: CommonAccessToken): Promise<number>;
 }

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -1,0 +1,6 @@
+import { CommonAccessToken } from "..";
+
+export interface CTIStore {
+  storeToken(token: CommonAccessToken): Promise<void>;
+  getTokenCount(token: CommonAccessToken): Promise<number>;
+}

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -1,7 +1,7 @@
 import { CommonAccessToken } from '..';
-import { CTIStore } from './interface';
+import { ICTIStore } from './interface';
 
-export class MemoryCTIStore implements CTIStore {
+export class MemoryCTIStore implements ICTIStore {
   private store: { [key: string]: number } = {};
 
   async storeToken(token: CommonAccessToken): Promise<number> {

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -4,7 +4,7 @@ import { CTIStore } from './interface';
 export class MemoryCTIStore implements CTIStore {
   private store: { [key: string]: number } = {};
 
-  async storeToken(token: CommonAccessToken): Promise<void> {
+  async storeToken(token: CommonAccessToken): Promise<number> {
     const cti = token.cti;
     if (cti) {
       if (this.store[cti]) {
@@ -12,7 +12,9 @@ export class MemoryCTIStore implements CTIStore {
       } else {
         this.store[cti] = 1;
       }
+      return this.store[cti];
     }
+    return 0;
   }
 
   async getTokenCount(token: CommonAccessToken): Promise<number> {

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -1,0 +1,25 @@
+import { CommonAccessToken } from '..';
+import { CTIStore } from './interface';
+
+export class MemoryCTIStore implements CTIStore {
+  private store: { [key: string]: number } = {};
+
+  async storeToken(token: CommonAccessToken): Promise<void> {
+    const cti = token.cti;
+    if (cti) {
+      if (this.store[cti]) {
+        this.store[cti] += 1;
+      } else {
+        this.store[cti] = 1;
+      }
+    }
+  }
+
+  async getTokenCount(token: CommonAccessToken): Promise<number> {
+    const cti = token.cti;
+    if (cti) {
+      return this.store[cti] || 0;
+    }
+    return 0;
+  }
+}

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -1,0 +1,28 @@
+import { Redis } from 'ioredis';
+import { ICTIStore } from './interface';
+import { CommonAccessToken } from '..';
+
+export class RedisCTIStore implements ICTIStore {
+  private client: Redis;
+
+  constructor(redisUrl: URL) {
+    this.client = new Redis(redisUrl.toString());
+  }
+
+  async storeToken(token: CommonAccessToken): Promise<number> {
+    const cti = token.cti;
+    if (cti) {
+      const count = await this.client.incr(cti);
+      return count;
+    }
+    return 0;
+  }
+
+  async getTokenCount(token: CommonAccessToken): Promise<number> {
+    const cti = token.cti;
+    if (cti) {
+      return parseInt((await this.client.get(cti)) || '0');
+    }
+    return 0;
+  }
+}

--- a/src/validators/http.ts
+++ b/src/validators/http.ts
@@ -13,7 +13,7 @@ import {
   CloudFrontResponse
 } from 'aws-lambda';
 import { CommonAccessTokenDict } from '../cat';
-import { CTIStore } from '../stores/interface';
+import { ICTIStore } from '../stores/interface';
 
 interface HttpValidatorKey {
   kid: string;
@@ -28,7 +28,7 @@ export interface HttpValidatorOptions {
   keys: HttpValidatorKey[];
   issuer: string;
   audience?: string[];
-  store?: CTIStore;
+  store?: ICTIStore;
 }
 
 export interface HttpResponse {
@@ -72,7 +72,7 @@ export class HttpValidator {
   private keys: { [key: string]: Buffer } = {};
   private opts: HttpValidatorOptions;
   private tokenUriParam: string;
-  private store?: CTIStore;
+  private store?: ICTIStore;
 
   constructor(opts: HttpValidatorOptions) {
     opts.keys.forEach((k: HttpValidatorKey) => {

--- a/src/validators/http.ts
+++ b/src/validators/http.ts
@@ -35,6 +35,7 @@ export interface HttpResponse {
   status: number;
   message?: string;
   claims?: CommonAccessTokenDict;
+  count?: number;
 }
 
 export class NoTokenFoundError extends Error {
@@ -159,9 +160,10 @@ export class HttpValidator {
         });
         cat = result.cat;
         if (!result.error) {
+          let count;
           // CAT is acceptable
           if (cat && this.store) {
-            await this.store.storeToken(cat);
+            count = await this.store.storeToken(cat);
           }
           if (
             cat &&
@@ -211,7 +213,7 @@ export class HttpValidator {
               }
             }
           }
-          return { status: 200, claims: cat?.claims };
+          return { status: 200, claims: cat?.claims, count };
         } else {
           return {
             status: 401,


### PR DESCRIPTION
This PR adds support for a plugin framework for storing and counting token usage. Includes plugins for a memory store and a Redis store. Custom plugins can be developed by implementing the `ICTIStore` interface.

```javascript
export interface ICTIStore {
  storeToken(token: CommonAccessToken): Promise<number>;
  getTokenCount(token: CommonAccessToken): Promise<number>;
}
```