### PR TITLE
feat: support for handling `catif` claim

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,7 +285,6 @@ const base64encoded = await generator.generateFromJson(json, {
 
 Providing above token to the `HttpValidator` the validator will return with a status code `307` and the header `Location` with the value of `https://auth.example.net/?CAT=<newtoken>` where `<newtoken>` is created by the JSON specified in the `catif` claim.
 
-
 ## Token store plugins
 
 To enable token usage count the HTTP validators requires a way to store the token id:s that has been used. The following types of stores are supported today.

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Features:
 | Geohash (`geohash`)                                       | Yes          | No       |
 | Common Access Token Altitude (`catgeoalt`)                | Yes          | No       |
 | Common Access Token TLS Public Key (`cattpk`)             | Yes          | No       |
-| Common Access Token If (`catif`) claim                    | Yes          | No       |
+| Common Access Token If (`catif`) claim                    | Yes          | Yes      |
 | Common Access Token Renewal (`catr`) claim                | Yes          | No       |
 
 ## Requirements

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ try {
 ### Generate token
 
 ```javascript
-import { CAT, CommonAccessTokenRenewal } from '@eyevinn/cat';
+import { CAT } from '@eyevinn/cat';
 
 const generator = new CAT({
   keys: {
@@ -237,6 +237,54 @@ const base64encoded = await generator.generateFromJson(
   }
 );
 ```
+
+This example generates a token with a `catif` claim.
+
+```javascript
+import { CAT } from '@eyevinn/cat';
+
+const generator = new CAT({
+  keys: {
+    Symmetric256: Buffer.from(
+      '403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d79569388',
+      'hex'
+    )
+  }
+});
+
+const json = {
+  iss: 'eyevinn',
+  exp: Math.floor(Date.now() / 1000) - 60,
+  cti: 'foobar',
+  catif: {
+    exp: [
+      307,
+      {
+        Location: [
+          'https://auth.example.net/?CAT=',
+          {
+            iss: null,
+            iat: null,
+            catu: {
+              host: { 'exact-match': 'auth.example.net' }
+            }
+          }
+        ]
+      },
+      'Symmetric256'
+    ]
+  }
+};
+const base64encoded = await generator.generateFromJson(json, {
+  type: 'mac',
+  alg: 'HS256',
+  kid: 'Symmetric256',
+  generateCwtId: true
+});
+```
+
+Providing above token to the `HttpValidator` the validator will return with a status code `307` and the header `Location` with the value of `https://auth.example.net/?CAT=<newtoken>` where `<newtoken>` is created by the JSON specified in the `catif` claim.
+
 
 ## Token store plugins
 

--- a/src/catif.test.ts
+++ b/src/catif.test.ts
@@ -1,0 +1,48 @@
+import { CommonAccessTokenIf } from './catif';
+
+describe('Common Access Token If', () => {
+  test('can be constructed from a dict', async () => {
+    const basic = CommonAccessTokenIf.fromDict({
+      exp: [
+        307,
+        {
+          Location: 'https://auth.example.net/'
+        }
+      ]
+    });
+    expect(basic.toDict()).toEqual({
+      exp: [307, { Location: 'https://auth.example.net/' }]
+    });
+
+    const advanced = CommonAccessTokenIf.fromDict({
+      exp: [
+        307,
+        {
+          Location: [
+            'https://auth.example.net/?CAT=',
+            {
+              iss: null,
+              iat: null
+            }
+          ]
+        },
+        'mykey'
+      ]
+    });
+    expect(advanced.toDict()).toEqual({
+      exp: [
+        307,
+        {
+          Location: [
+            'https://auth.example.net/?CAT=',
+            {
+              iss: null,
+              iat: null
+            }
+          ]
+        },
+        'mykey'
+      ]
+    });
+  });
+});

--- a/src/catif.ts
+++ b/src/catif.ts
@@ -1,7 +1,15 @@
-import { claimsToLabels, labelsToClaim } from './cat';
+import { claimsToLabels, CommonAccessTokenDict, labelsToClaim } from './cat';
 
 type CatIfValue = Map<number, [number, { [key: string]: string }]>;
 export type CommonAccessTokenIfMap = Map<number, CatIfValue>;
+
+export type CatIfDictValue = {
+  [key: string]: [
+    number,
+    { [header: string]: string | [string, CommonAccessTokenDict] },
+    string?
+  ];
+};
 
 export class CommonAccessTokenIf {
   private catIfMap: CommonAccessTokenIfMap = new Map();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -110,3 +110,9 @@ export class MethodNotAllowedError extends Error {
     super(`HTTP Method ${method} not allowed`);
   }
 }
+
+export class InvalidCatIfError extends Error {
+  constructor(reason: string) {
+    super(reason);
+  }
+}

--- a/src/validators/http.test.ts
+++ b/src/validators/http.test.ts
@@ -449,6 +449,51 @@ describe('HTTP Request CAT Validator with auto renew', () => {
     expect(response.getHeader('cta-common-access-token')).not.toBeDefined();
   });
 
+  test('can follow the directives in catif claim when no acceptable token is provided', async () => {
+    const json = {
+      iss: 'eyevinn',
+      exp: Math.floor(Date.now() / 1000) - 60,
+      cti: 'foobar',
+      catif: {
+        exp: [
+          307,
+          {
+            Location: 'https://auth.example.net/'
+          }
+        ]
+      }
+    };
+    base64encoded = await generator.generateFromJson(json, {
+      type: 'mac',
+      alg: 'HS256',
+      kid: 'Symmetric256',
+      generateCwtId: true
+    });
+    // Validate auto renew
+    const httpValidator = new HttpValidator({
+      keys: [
+        {
+          kid: 'Symmetric256',
+          key: Buffer.from(
+            '403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d79569388',
+            'hex'
+          )
+        }
+      ],
+      issuer: 'eyevinn'
+    });
+    const request = createRequest({
+      method: 'GET',
+      headers: {
+        'CTA-Common-Access-Token': base64encoded
+      }
+    });
+    const response = createResponse();
+    const result = await httpValidator.validateHttpRequest(request, response);
+    expect(response.getHeader('Location')).toBe('https://auth.example.net/');
+    expect(result.status).toBe(307);
+  });
+
   test.skip('can handle autorenew of type redirect', async () => {
     // Validate auto renew
     const httpValidator = new HttpValidator({

--- a/src/validators/http.test.ts
+++ b/src/validators/http.test.ts
@@ -494,6 +494,76 @@ describe('HTTP Request CAT Validator with auto renew', () => {
     expect(result.status).toBe(307);
   });
 
+  test('can generate new cat claims based on catif directives', async () => {
+    const json = {
+      iss: 'eyevinn',
+      exp: Math.floor(Date.now() / 1000) - 60,
+      cti: 'foobar',
+      catif: {
+        exp: [
+          307,
+          {
+            Location: [
+              'https://auth.example.net/?CAT=',
+              {
+                iss: null,
+                iat: null,
+                catu: {
+                  host: { 'exact-match': 'auth.example.net' }
+                }
+              }
+            ]
+          },
+          'Symmetric256'
+        ]
+      }
+    };
+    base64encoded = await generator.generateFromJson(json, {
+      type: 'mac',
+      alg: 'HS256',
+      kid: 'Symmetric256',
+      generateCwtId: true
+    });
+    // Validate auto renew
+    const httpValidator = new HttpValidator({
+      keys: [
+        {
+          kid: 'Symmetric256',
+          key: Buffer.from(
+            '403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d79569388',
+            'hex'
+          )
+        }
+      ],
+      issuer: 'eyevinn'
+    });
+    const request = createRequest({
+      method: 'GET',
+      headers: {
+        'CTA-Common-Access-Token': base64encoded
+      }
+    });
+    const response = createResponse();
+    const result = await httpValidator.validateHttpRequest(request, response);
+    expect(response.getHeader('Location')).toBeDefined();
+    const location = new URL(response.getHeader('Location') as string);
+    const newToken = location.searchParams.get('CAT');
+    expect(newToken).toBeDefined();
+    expect(result.status).toBe(307);
+    const validator = new CAT({
+      keys: {
+        Symmetric256: Buffer.from(
+          '403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d79569388',
+          'hex'
+        )
+      }
+    });
+    const result2 = await validator.validate(newToken!, 'mac', {
+      issuer: 'eyevinn'
+    });
+    expect(result2.cat?.claims.iat).toBeDefined();
+  });
+
   test.skip('can handle autorenew of type redirect', async () => {
     // Validate auto renew
     const httpValidator = new HttpValidator({


### PR DESCRIPTION
Based on directives in `catif` a new CAT token can be generated for example