### PR TITLE
fix: query param matching handles params that are not in same order

### DIFF
--- a/examples/parse.ts
+++ b/examples/parse.ts
@@ -10,7 +10,8 @@ async function main() {
     }
   });
   const result = await parser.validate(process.argv[2], 'mac', {
-    issuer: 'eyevinn'
+    issuer: 'eyevinn',
+    url: process.argv[3] ? new URL(process.argv[3]) : undefined
   });
   console.dir(result, { depth: null });
 }

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -331,7 +331,10 @@ export class CommonAccessToken {
     const recipient = {
       key: key.k
     };
-    const encoder = new cbor.Encoder({ mapsAsObjects: false });
+    const encoder = new cbor.Encoder({
+      mapsAsObjects: false,
+      useRecords: false
+    });
     if (!opts?.noCwtTag) {
       const plaintext = encoder.encode(this.payload);
       const coseMessage = await cose.mac.create(
@@ -339,7 +342,10 @@ export class CommonAccessToken {
         plaintext as unknown as string,
         recipient
       );
-      const decoder = new cbor.Decoder({ mapsAsObjects: false });
+      const decoder = new cbor.Decoder({
+        mapsAsObjects: false,
+        useRecords: false
+      });
       const decoded = decoder.decode(coseMessage).value;
       const coseTag = new cbor.Tag(decoded, 17);
       const cwtTag = new cbor.Tag(coseTag, CWT_TAG);
@@ -362,14 +368,20 @@ export class CommonAccessToken {
       expectCwtTag: boolean;
     }
   ): Promise<void> {
-    const decoder = new cbor.Decoder({ mapsAsObjects: false });
+    const decoder = new cbor.Decoder({
+      mapsAsObjects: false,
+      useRecords: false
+    });
     const coseMessage = decoder.decode(token);
     Log(coseMessage, { depth: null });
     if (opts?.expectCwtTag && coseMessage.tag !== 61) {
       throw new Error('Expected CWT tag');
     }
     if (coseMessage.tag === CWT_TAG) {
-      const encoder = new cbor.Encoder({ mapsAsObjects: false });
+      const encoder = new cbor.Encoder({
+        mapsAsObjects: false,
+        useRecords: false
+      });
       const cborCoseMessage = encoder.encode(coseMessage.value);
       Log({
         kid: key.kid,
@@ -388,7 +400,10 @@ export class CommonAccessToken {
   }
 
   public async sign(key: CWTSigningKey, alg: string): Promise<void> {
-    const encoder = new cbor.Encoder({ mapsAsObjects: false });
+    const encoder = new cbor.Encoder({
+      mapsAsObjects: false,
+      useRecords: false
+    });
     const plaintext = encoder.encode(this.payload).toString('hex');
     const headers = {
       p: { alg: alg },
@@ -405,7 +420,10 @@ export class CommonAccessToken {
     key: CWTVerifierKey
   ): Promise<CommonAccessToken> {
     const buf = await cose.sign.verify(token, { key: key });
-    const decoder = new cbor.Decoder({ mapsAsObjects: false });
+    const decoder = new cbor.Decoder({
+      mapsAsObjects: false,
+      useRecords: false
+    });
     this.payload = await decoder.decode(
       Buffer.from(buf.toString('hex'), 'hex')
     );

--- a/src/cattypes/match.ts
+++ b/src/cattypes/match.ts
@@ -40,6 +40,18 @@ export const labelsToMatch: { [key: number]: MatchType } = {
   '-2': 'sha512-256-match'
 };
 
+export const matchTypeValidator: {
+  [key: string]: (value: MatchValue) => boolean;
+} = {
+  'exact-match': (value: MatchValue) => typeof value === 'string',
+  'prefix-match': (value: MatchValue) => typeof value === 'string',
+  'suffix-match': (value: MatchValue) => typeof value === 'string',
+  'contains-match': (value: MatchValue) => typeof value === 'string',
+  'regex-match': (value: MatchValue) => Array.isArray(value),
+  'sha256-match': (value: MatchValue) => typeof value === 'string',
+  'sha512-256-match': (value: MatchValue) => typeof value === 'string'
+};
+
 export class MatchTypeError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/catu.test.ts
+++ b/src/catu.test.ts
@@ -239,4 +239,14 @@ describe('Common Access Token Uri', () => {
     expect(await catu.match(uri)).toBeTruthy();
     expect(await catu.match(uri2)).toBeTruthy();
   });
+
+  test('can match query params', async () => {
+    const catu = CommonAccessTokenUri.fromDict({
+      query: {
+        'exact-match': 'x=true&y=false&z=z'
+      }
+    });
+    const uri = new URL('https://example.com/path?y=false&x=true&z=z');
+    expect(await catu.match(uri)).toBeTruthy();
+  });
 });

--- a/src/catu.ts
+++ b/src/catu.ts
@@ -120,7 +120,7 @@ export class CommonAccessTokenUri {
     for (const [uriPart, uriPartMap] of this.catuMap) {
       const uriPartType = labelsToUriPart[uriPart];
       const matchLabel = uriPartMap.keys().next().value;
-      const matchValue = uriPartMap.get(matchLabel!);
+      let matchValue = uriPartMap.get(matchLabel!);
       let value;
       switch (uriPartType) {
         case 'scheme':
@@ -139,7 +139,12 @@ export class CommonAccessTokenUri {
           {
             const params = new URLSearchParams(uri.search);
             params.delete('cat');
+            params.sort();
             value = params.toString();
+            const matchValueParams = new URLSearchParams(
+              '?' + (matchValue as string)
+            );
+            matchValue = matchValueParams.toString();
           }
           break;
         case 'parent-path':

--- a/src/catu.ts
+++ b/src/catu.ts
@@ -4,6 +4,7 @@ import {
   match,
   matchToLabels,
   MatchType,
+  matchTypeValidator,
   MatchValue
 } from './cattypes/match';
 
@@ -121,6 +122,11 @@ export class CommonAccessTokenUri {
       const uriPartType = labelsToUriPart[uriPart];
       const matchLabel = uriPartMap.keys().next().value;
       let matchValue = uriPartMap.get(matchLabel!);
+      if (!matchTypeValidator[labelsToMatch[matchLabel!]](matchValue!)) {
+        throw new InvalidCatuError(
+          `Invalid match value type for ${labelsToMatch[matchLabel!]}`
+        );
+      }
       let value;
       switch (uriPartType) {
         case 'scheme':

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
   CommonAccessTokenDict,
   CommonAccessTokenFactory
 } from './cat';
-import { KeyNotFoundError } from './errors';
+import { InvalidCatuError, KeyNotFoundError } from './errors';
 import { fromBase64Url, generateRandomHex, toBase64NoPadding } from './util';
 
 export { CommonAccessToken } from './cat';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
   CommonAccessTokenDict,
   CommonAccessTokenFactory
 } from './cat';
-import { InvalidCatuError, KeyNotFoundError } from './errors';
+import { KeyNotFoundError } from './errors';
 import { fromBase64Url, generateRandomHex, toBase64NoPadding } from './util';
 
 export { CommonAccessToken } from './cat';


### PR DESCRIPTION
This PR addresses #45 and fix an issue where query param matching required the params to be in the same order. This is solved by parsing the query param string and sort the params before string comparison.

In addition this PR includes:

Validate types for match in catu claim is according to spec:

```
match = {
  ? exact-match ^ => tstr,
  ? prefix-match ^ => tstr,
  ? suffix-match ^ => tstr,
  ? contains-match ^ => tstr,
  ? regex-match ^ => [ tstr, * tstr ],
  ? sha256-match ^ => bstr,
  ? sha512-256-match ^ => bstr
}
```

And also adds the `useRecords=false` option to CBOR encoder/decoder