### PR TITLE
fix: support passing CAT in CloudFront querystring

### DIFF
--- a/src/validators/http.ts
+++ b/src/validators/http.ts
@@ -176,7 +176,11 @@ export class HttpValidator {
         }
       });
     }
-    requestLike.url = cfRequest.uri;
+    if (cfRequest.querystring) {
+      requestLike.url = `${cfRequest.uri}?${cfRequest.querystring}`;
+    } else {
+      requestLike.url = cfRequest.uri;
+    }
 
     const result = await this.validateHttpRequest(
       requestLike as IncomingMessage,


### PR DESCRIPTION
The code for fetching a CAT from the querystring looks at the incoming URL. The code for translating a Lambda@edge request to the expected `node:http` `IncomingMessage` doesn't include the querystring at all, leading to it being impossible to pass a CAT in the querystring when using Lambda@edge.

This commit fixes this by including the querystring in the passed URL if it is set.